### PR TITLE
Fixed layout of chat page

### DIFF
--- a/src/components/ChatWrapper.tsx
+++ b/src/components/ChatWrapper.tsx
@@ -11,14 +11,15 @@ export const ChatWrapper = ({
   sessionId: string;
   initialMessages: Message[];
 }) => {
-  const { messages, handleInputChange, handleSubmit, input, setInput } = useChat({
-    api: "/api/chat-stream",
-    body: { sessionId },
-    initialMessages,
-  });
+  const { messages, handleInputChange, handleSubmit, input, setInput } =
+    useChat({
+      api: "/api/chat-stream",
+      body: { sessionId },
+      initialMessages,
+    });
 
   return (
-    <div className="relative min-h-full bg-zinc-900 flex divide-y divide-zinc-700 flex-col justify-between gap-2">
+    <div className="min-h-full bg-zinc-900 flex divide-y divide-zinc-700 flex-col justify-between gap-2">
       <div className="flex-1 text-black bg-zinc-800 justify-between flex flex-col">
         <Messages messages={messages} />
       </div>


### PR DESCRIPTION
Removed the relative class on the ChatWrapper to fix the layout for the page. All the components were getting overlayed due to the positioning being disturbed by the relative class and removeing it caused the components to look and behave normally